### PR TITLE
Fixed ioctl window size magic number on darwin and bsd

### DIFF
--- a/src/term_size.cr
+++ b/src/term_size.cr
@@ -5,8 +5,17 @@ lib LibC
     x_pixel : LibC::Short
     y_pixel : LibC::Short
   end
-
-  TIOCGWINSZ = 0x5413 # Magic number.
+  
+  # TIOCGWINSZ is a magic number passed to ioctl that requests the current
+  # terminal window size. It is platform dependent (see
+  # https://stackoverflow.com/a/4286840).
+  {% begin %}
+    {% if flag?(:darwin) || flag?(:bsd) %}
+      TIOCGWINSZ = 0x40087468
+    {% elsif flag?(:unix) %}
+      TIOCGWINSZ = 0x5413
+    {% end %}
+  {% end %}
 
   fun ioctl(fd : LibC::Int, request : LibC::SizeT, winsize : LibC::Winsize*) : LibC::Int
 end


### PR DESCRIPTION
When trying to run `ic` on my Mac (after building it locally), I got the following stack trace:

```
$ ./bin/ic
# (Crash only occurs when you press a key)
ic(1.5.1):001> Unhandled exception: Error retrieving terminal size: ioctl TIOCGWINSZ: ENOTTY (Exception)
   from lib/reply/src/term_size.cr:19:7 in 'size'
  from lib/reply/src/term_size.cr:25:7 in 'width'
  from lib/reply/src/expression_editor.cr:279:17 in 'width'
  from lib/reply/src/expression_editor.cr:274:41 in 'line_height'
  from lib/reply/src/expression_editor.cr:56:57 in 'expression_height'
  from lib/reply/src/expression_editor.cr:713:10 in 'rewind_cursor'
  from lib/reply/src/expression_editor.cr:576:7 in 'on_char'
  from lib/reply/src/reader.cr:189:34 in 'read_next'
  from lib/reply/src/reader.cr:226:15 in 'run'
  from src/ic.cr:61:3 in '__crystal_main'
  from share/crystal-ic/src/crystal/main.cr:115:5 in 'main_user_code'
  from share/crystal-ic/src/crystal/main.cr:101:7 in 'main'
  from share/crystal-ic/src/crystal/main.cr:127:3 in 'main'
```

After digging into things a little bit, I found that the ioctl magic number `TIOCGWINSZ` varies depending on platform - there are more details in [this stackoverflow post](https://stackoverflow.com/questions/4286158/how-do-i-get-width-and-height-of-my-terminal-with-ioctl), specifically in [this answer](https://stackoverflow.com/a/4286840). I have verified on my mac that the magic number 0x40087468 is correct, and I assume that the previous value (0x5413) works on other unix systems.

I threw in a little macro that checks the current OS, and chooses an appropriate value of `TIOCGWINSZ`. I rebuilt`ic` using my fork of `reply`, and it now works fine. Specs pass in this branch.

Hope that this helps! Let me know if any changes should be made to this branch.