### PR TITLE
Recalculate completion entries when crossing :: namespace boundary

### DIFF
--- a/spec/reader_spec.cr
+++ b/spec/reader_spec.cr
@@ -254,7 +254,7 @@ module Reply
       reader.auto_completion.verify(open: true, entries: %w(hello hey), name_filter: "h", selection_pos: 0)
       reader.editor.verify("42.hello")
 
-      SpecHelper.send(pipe_in, "\e\t") # shit_tab
+      SpecHelper.send(pipe_in, "\e\t") # shift_tab
       reader.auto_completion.verify(open: true, entries: %w(hello hey), name_filter: "h", selection_pos: 1)
       reader.editor.verify("42.hey")
 


### PR DESCRIPTION
When playing around with `ic`, I noticed the tab-completion wasn't helping when I needed to descend down nested module / class names. I added some extra conditions in the `on_tab` method in reply to detect when that was happening and trigger another `on_completion` run for the new namespace layer. 

I couldn't think of an effective way to write tests for this, since reply tries to be `crystal` agnostic it looks like, and this is fairly crystal specific. Let me know if you have any ideas for writing a spec, would be happy to write any suggestions :)