### PR TITLE
Fix Windows compilation for Crystal 1.13+

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ description: "Shard to create a REPL interface"
 authors:
   - I3oris <boris31.resch@gmail.com>
 
-crystal: 1.5.0
+crystal: 1.13.0
 
 license: MIT
 

--- a/src/char_reader.cr
+++ b/src/char_reader.cr
@@ -43,20 +43,9 @@ module Reply
       @slice_buffer = Bytes.new(buffer_size)
     end
 
-    def read_char(from io : T = STDIN) forall T
-      {% if flag?(:win32) && T <= IO::FileDescriptor %}
-        handle = LibC._get_osfhandle(io.fd)
-        raise RuntimeError.from_errno("_get_osfhandle") if handle == -1
-
-        raw(io) do
-          LibC.ReadConsoleA(LibC::HANDLE.new(handle), @slice_buffer, @slice_buffer.size, out nb_read, nil)
-
-          parse_escape_sequence(@slice_buffer[0...nb_read])
-        end
-      {% else %}
+    def read_char(from io : IO = STDIN)
         nb_read = raw(io, &.read(@slice_buffer))
         parse_escape_sequence(@slice_buffer[0...nb_read])
-      {% end %}
     end
 
     private def parse_escape_sequence(chars : Bytes) : Char | Sequence | String?
@@ -184,15 +173,3 @@ module Reply
     end
   end
 end
-
-{% if flag?(:win32) %}
-  lib LibC
-    STD_INPUT_HANDLE = -10
-
-    fun ReadConsoleA(hConsoleInput : Void*,
-                     lpBuffer : Void*,
-                     nNumberOfCharsToRead : UInt32,
-                     lpNumberOfCharsRead : UInt32*,
-                     pInputControl : Void*) : UInt8
-  end
-{% end %}

--- a/src/term_size.cr
+++ b/src/term_size.cr
@@ -120,10 +120,7 @@ end
       dwMaximumWindowSize : COORD
     end
 
-    STD_OUTPUT_HANDLE = -11
-
     fun GetConsoleScreenBufferInfo(hConsoleOutput : Void*, lpConsoleScreenBufferInfo : CONSOLE_SCREEN_BUFFER_INFO*) : Void
-    fun GetStdHandle(nStdHandle : UInt32) : Void*
   end
 {% else %}
   lib LibC


### PR DESCRIPTION
Some of the internal definitions are no longer necessary and clash with a newer stdlib, especially crystal-lang/crystal#14501 which replaces C file descriptors with their underlying Win32 handles.

`spec/reader_spec.cr` will run on Windows too, however it lacks the proper fiber synchronization. Also it appears REPLy expects the input to use `\r\n` on Windows only, but the specs do not account for that.

What was the reason behind making Ctrl+Enter exclusive to Windows? Isn't it easier to just strip the CRLF sequences at the beginning of `Reply::CharReader#parse_escape_sequence`?