### PR TITLE
Stop using parameter names ending with `?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ end
 require "reply"
 
 class MyReader < Reply::Reader
-  def prompt(io : IO, line_number : Int32, color? : Bool) : Nil
+  def prompt(io : IO, line_number : Int32, color : Bool) : Nil
     # Display a custom prompt
   end
 

--- a/examples/crystal_repl.cr
+++ b/examples/crystal_repl.cr
@@ -46,8 +46,8 @@ CONTINUE_ERROR = [
 WORD_DELIMITERS = {{" \n\t+-*/,;@&%<>^\\[](){}|.~".chars}}
 
 class CrystalReader < Reply::Reader
-  def prompt(io : IO, line_number : Int32, color? : Bool) : Nil
-    io << "crystal".colorize.blue.toggle(color?)
+  def prompt(io : IO, line_number : Int32, color : Bool) : Nil
+    io << "crystal".colorize.blue.toggle(color)
     io << ':'
     io << sprintf("%03d", line_number)
     io << "> "

--- a/spec/expression_editor_spec.cr
+++ b/spec/expression_editor_spec.cr
@@ -391,7 +391,7 @@ module Reply
     end
 
     it "is aligned when prompt size change" do
-      editor = ExpressionEditor.new do |line_number, _color?|
+      editor = ExpressionEditor.new do |line_number, _color|
         "*" * line_number + ">" # A prompt that increase its size at each line
       end
       editor.output = IO::Memory.new

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -15,7 +15,7 @@ module Reply
       height_got = nil
 
       display_got = String.build do |io|
-        height_got = self.display_entries(io, color?: false, width: with_width, max_height: max_height, min_height: min_height)
+        height_got = self.display_entries(io, color: false, width: with_width, max_height: max_height, min_height: min_height)
       end
       display_got.should eq display
       height_got.should eq height
@@ -148,7 +148,7 @@ module Reply
     end
 
     def self.expression_editor
-      editor = ExpressionEditor.new do |line_number, _color?|
+      editor = ExpressionEditor.new do |line_number, _color|
         # Prompt size = 5
         "p:#{sprintf("%02d", line_number)}>"
       end

--- a/src/auto_completion.cr
+++ b/src/auto_completion.cr
@@ -56,7 +56,7 @@ module Reply
     # If closed, do nothing.
     #
     # Returns the actual displayed height.
-    def display_entries(io, color? = true, width = Term::Size.width, max_height = 10, min_height = 0) : Int32 # ameba:disable Metrics/CyclomaticComplexity
+    def display_entries(io, color = true, width = Term::Size.width, max_height = 10, min_height = 0) : Int32 # ameba:disable Metrics/CyclomaticComplexity
       if cleared?
         min_height.times { io.puts }
         return min_height
@@ -68,7 +68,7 @@ module Reply
       height = 0
 
       # Print title:
-      if color?
+      if color
         @display_title.call(io, @title)
       else
         io << @title << ":"
@@ -116,7 +116,7 @@ module Reply
 
           if r + c*nb_rows == @selection_pos
             # Colorize selection:
-            if color?
+            if color
               @display_selected_entry.call(io, entry_str)
             else
               io << ">" + entry_str[...-1] # if no color, remove last spaces to let place to '*'.
@@ -124,7 +124,7 @@ module Reply
           else
             # Display entry_str, with @name_filter prefix in bright:
             unless entry.empty?
-              if color?
+              if color
                 io << @display_entry.call(io, @name_filter, entry_str.lchop(@name_filter))
               else
                 io << entry_str
@@ -132,7 +132,7 @@ module Reply
             end
           end
         end
-        io << Term::Cursor.clear_line_after if color?
+        io << Term::Cursor.clear_line_after if color
         io.puts
       end
 

--- a/src/expression_editor.cr
+++ b/src/expression_editor.cr
@@ -846,9 +846,9 @@ module Reply
       {start, end_}
     end
 
-    private def print_line(io, colorized_line, line_index, line_size, prompt?, first?, is_last_part?)
-      if prompt?
-        io.puts unless first?
+    private def print_line(io, colorized_line, line_index, line_size, prompt, first, is_last_part)
+      if prompt
+        io.puts unless first
         print_prompt(io, line_index)
       end
       io.print colorized_line
@@ -860,10 +860,10 @@ module Reply
       # prompt>  bar                  |    extra line feed, so computes based on `%` or `//` stay exact.
       # prompt>end                    |
       # ```
-      io.puts if is_last_part? && last_part_size(line_size) == 0
+      io.puts if is_last_part && last_part_size(line_size) == 0
     end
 
-    private def sync_output
+    private def sync_output(&)
       if (output = @output).is_a?(IO::FileDescriptor) && output.tty?
         # Disallowing the synchronization reduce blinking on some terminal like vscode (#10)
         output.sync = false

--- a/src/reader.cr
+++ b/src/reader.cr
@@ -11,7 +11,7 @@ module Reply
   #
   # ```
   # class MyReader < Reply::Reader
-  #   def prompt(io, line_number, color?)
+  #   def prompt(io, line_number, color)
   #     io << "reply> "
   #   end
   # end
@@ -60,9 +60,9 @@ module Reply
     delegate :word_delimiters, :word_delimiters=, to: @editor
 
     def initialize
-      @editor = ExpressionEditor.new do |expr_line_number, color?|
+      @editor = ExpressionEditor.new do |expr_line_number, color|
         String.build do |io|
-          prompt(io, @line_number + expr_line_number, color?)
+          prompt(io, @line_number + expr_line_number, color)
         end
       end
 
@@ -72,11 +72,11 @@ module Reply
       @auto_completion.set_display_selected_entry(&->auto_completion_display_selected_entry(IO, String))
 
       @editor.set_header do |io, previous_height|
-        @auto_completion.display_entries(io, color?, max_height: {10, Term::Size.height - 1}.min, min_height: previous_height)
+        @auto_completion.display_entries(io, color, max_height: {10, Term::Size.height - 1}.min, min_height: previous_height)
       end
 
       @editor.set_footer do |io, _previous_height|
-        @search.footer(io, color?)
+        @search.footer(io, color)
       end
 
       @editor.set_highlight(&->highlight(String))
@@ -88,10 +88,10 @@ module Reply
 
     # Override to customize the prompt.
     #
-    # Toggle the colorization following *color?*.
+    # Toggle the colorization following *color*.
     #
     # default: `$:001> `
-    def prompt(io : IO, line_number : Int32, color? : Bool)
+    def prompt(io : IO, line_number : Int32, color : Bool)
       io << "$:"
       io << sprintf("%03d", line_number)
       io << "> "
@@ -489,10 +489,10 @@ module Reply
       end
     end
 
-    private def search_and_replace(query = nil, reuse_index? = false)
+    private def search_and_replace(query = nil, reuse_index = false)
       @search.query = query if query
 
-      from_index = reuse_index? ? @history.index - 1 : @history.size - 1
+      from_index = reuse_index ? @history.index - 1 : @history.size - 1
 
       result = @search.search(@history, from_index)
       if result

--- a/src/search.cr
+++ b/src/search.cr
@@ -10,9 +10,9 @@ module Reply
       x : Int32,
       y : Int32
 
-    def footer(io : IO, color? : Bool)
+    def footer(io : IO, color : Bool)
       if open?
-        io << "search: #{@query.colorize.toggle(failed? && color?).bold.red}_"
+        io << "search: #{@query.colorize.toggle(failed? && color).bold.red}_"
         1
       else
         0


### PR DESCRIPTION
This was actually not intended to be possible - see https://github.com/crystal-lang/crystal/issues/10917
