### PR TITLE
Add helper for defining commands as methods prefixed with "do_"

### DIFF
--- a/spec/do_methods_spec.cr
+++ b/spec/do_methods_spec.cr
@@ -1,0 +1,30 @@
+require "./spec_helper"
+require "../src/reader"
+require "../src/do_methods"
+
+class MyRepl < Reply::Reader
+  @[Reply::Help("This is a test command")]
+  def do_test(arg : String)
+    # do nothing
+    false
+  end
+
+  include Reply::DoMethods
+  class_property commands # for test accessibility
+
+  def verify_commands
+    test_cmd = @@commands["test"]
+    test_cmd.doc.should eq "This is a test command"
+    test_cmd.action.call(self, "irrelevant").should be_false
+
+    help_cmd = @@commands["help"]
+    help_cmd.doc.should eq "Print help for each command. Specify help [command] for help on a specific command"
+    help_cmd.action.call(self, "").should be_false
+  end
+end
+
+describe Reply::DoMethods do
+  it "loads the command info right" do
+    MyRepl.new.verify_commands
+  end
+end

--- a/src/do_methods.cr
+++ b/src/do_methods.cr
@@ -1,0 +1,72 @@
+module Reply
+  annotation Help
+  end
+  class DoCommand(R)
+    property action : R, String -> Bool
+    property doc : String?
+
+    def initialize(@action : Proc(R, String, Bool), @doc : String?)
+    end
+  end
+
+  module DoMethods
+    def do_help(arg : String? = nil) : Bool?
+      return true if @@commands.empty?
+      if arg && !arg.empty?
+        if cmd = @@commands[arg]
+          puts "#{arg}: #{cmd.doc}"
+        else
+          puts "Command '#{arg}' not found"
+        end
+      else
+        longest_cmd = @@commands.keys.max_by(&.size).size
+        @@commands.each do |name, command|
+          puts "#{name.rjust longest_cmd}: #{command.doc}"
+        end
+      end
+      false
+    end
+
+    def cmdloop
+      read_loop do |expr|
+        command, arg = if expr.includes? ' '
+                         expr.split ' ', limit: 2, remove_empty: true
+                       else
+                         {expr, ""}
+                       end
+        if cmd = @@commands[command]?
+          if cmd.action.call self, arg
+            exit
+          end
+        else
+          puts "unknown command #{command}"
+          puts "available commands are:"
+          puts @@commands.keys.join '\n'
+          do_help
+        end
+      end
+    end
+
+    macro included
+      @@commands : Hash(String, ::Reply::DoCommand({{@type}})) = {
+        "help" => ::Reply::DoCommand.new(
+          action: ->(repl : {{@type}}, arg : String) { repl.do_help arg },
+          doc: "Print help for each command. Specify help [command] for help on a specific command",
+        )
+      }
+      {% for method in @type.methods %}
+        {% if method.name.stringify.starts_with? "do_" %}
+          %action = ->(repl : {{@type}}, arg : String) {
+            repl.{{method.name}}(arg)
+          }
+          %doc = {% if ant = method.annotation(::Reply::Help) %}
+            {{ant[0]}}
+          {% else %}
+            nil
+          {% end %}
+          @@commands[{{ method.name.stringify[3..] }}] = ::Reply::DoCommand.new %action, %doc
+        {% end %}
+      {% end %}
+    end
+  end
+end

--- a/src/do_methods.cr
+++ b/src/do_methods.cr
@@ -49,6 +49,22 @@ module Reply
       end
     end
 
+    # Override this method to provide name completion for arguments to a command.
+    def do_auto_complete(name_filter : String, expression_before : String) : {String, Array(String)}
+      {"", [] of String}
+    end
+
+    # `DoMethods#auto_complete` (this method) matches the first command to the
+    # commands defined by the `do_` methods, and hands off any subsequent
+    # completion requests to `#do_auto_complete`.
+    def auto_complete(name_filter : String, expression_before : String) : {String, Array(String)}
+      if expression_before.empty? || expression_before == "help "
+        {name_filter, @@commands.keys.select &.starts_with? name_filter}
+      else
+        do_auto_complete name_filter, expression_before
+      end
+    end
+
     macro included
       @@commands : Hash(String, ::Reply::DoCommand({{@type}})) = {
         "help" => ::Reply::DoCommand.new(

--- a/src/do_methods.cr
+++ b/src/do_methods.cr
@@ -1,6 +1,7 @@
 module Reply
   annotation Help
   end
+
   class DoCommand(R)
     property action : R, String -> Bool
     property doc : String?
@@ -14,14 +15,15 @@ module Reply
       return true if @@commands.empty?
       if arg && !arg.empty?
         if cmd = @@commands[arg]
-          puts "#{arg}: #{cmd.doc}"
+          puts "    #{arg}        #{cmd.doc}"
         else
           puts "Command '#{arg}' not found"
         end
       else
+        puts "Available Commands:"
         longest_cmd = @@commands.keys.max_by(&.size).size
         @@commands.each do |name, command|
-          puts "#{name.rjust longest_cmd}: #{command.doc}"
+          puts "    #{name.rjust longest_cmd}        #{command.doc}"
         end
       end
       false

--- a/src/reply.cr
+++ b/src/reply.cr
@@ -1,4 +1,5 @@
 require "./reader"
+require "./do_methods"
 
 module Reply
   VERSION = "0.3.1"


### PR DESCRIPTION
This was inspired by the behavior of Python's cmd.Cmd. Include the module `DoMethods` and any method prefixed with `do_` gets converted into a command, which a new  `cmdloop` method is aware of. It also auto-generates some help info.

This is a bit of a MVP for this feature and could stand some iteration.