### PR TITLE
Add Ctrl+L as a recognized keybind to clear the console screen

### DIFF
--- a/src/char_reader.cr
+++ b/src/char_reader.cr
@@ -17,6 +17,7 @@ module Reply
       CTRL_E
       CTRL_F
       CTRL_K
+      CTRL_L
       CTRL_N
       CTRL_P
       CTRL_R
@@ -138,6 +139,8 @@ module Reply
         Sequence::CTRL_F
       when ctrl('k')
         Sequence::CTRL_K
+      when ctrl('l')
+        Sequence::CTRL_L
       when ctrl('n')
         Sequence::CTRL_N
       when ctrl('p')

--- a/src/reader.cr
+++ b/src/reader.cr
@@ -272,6 +272,7 @@ module Reply
         in .alt_b?          then @editor.move_word_backward
         in .ctrl_delete?    then @editor.update { delete_word }
         in .alt_d?          then on_alt_d
+        in .ctrl_l?         then on_ctrl_l
         in .ctrl_c?         then on_ctrl_c
         in .ctrl_r?         then on_ctrl_r
         in .ctrl_d?
@@ -421,6 +422,14 @@ module Reply
 
     private def on_ctrl_right(& : String ->)
       @editor.move_word_forward
+    end
+
+    # Option to use ANSI code to clear screen
+    # Should work on all modern terminals
+    #
+    # TODO: Test on a working Windows 10/11 environment.
+    private def on_ctrl_l
+      print "\x1Bc"
     end
 
     private def on_ctrl_c


### PR DESCRIPTION
This is a small addition that allows `reply` to accept Ctrl+L as a bind, and ties it to a function that clears the console screen.

I've tested and confirmed this works on Linux (EndeavourOS) by recompiling the [Crystal compiler](https://github.com/crystal-lang/crystal) and setting the most recent commit of my fork as its `reply` dependency. It acts as expected, including keeping the prompt and preserving existing input (and keeping syntax highlighting intact).

> Note: I was unable to confirm or deny functionality on Windows, as my existing Windows environment is not set up for development, and on trying to set it up I learned that it doesn't like Crystal or LLVM very much. As Windows support for Crystal itself is currently in an early stage I assume this is not a high priority, and since it uses an ANSI code it *should* still work in Windows Terminal. Nonetheless, further testing is encouraged if someone has an existing Win environment set up and wants to give it a go.